### PR TITLE
Add SVG hero banner; update masthead and post-rename URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
-# RSNA 2024 Lumbar Spine Degenerative Classification Solution
+<p align="center">
+  <img src="https://raw.githubusercontent.com/DaoyuanLi2816/rsna-2024-lumbar-spine/main/docs/banner.svg" alt="RSNA 2024 — lumbar spine degenerative classification with a three-track YOLOv8 pipeline (detect, classify, grade severity); Kaggle silver medal." width="880">
+</p>
+
+<div align="center">
 
 ![Python](https://img.shields.io/badge/Python-3.10-blue)
 ![Model](https://img.shields.io/badge/Model-YOLOv8-00FFFF)
-![Kaggle](https://img.shields.io/badge/Kaggle-Silver%20Medal-C0C0C0)
+[![Kaggle](https://img.shields.io/badge/Kaggle-Silver%20Medal-C0C0C0)](https://www.kaggle.com/certification/competitions/distiller/rsna-2024-lumbar-spine-degenerative-classification)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+</div>
 
 This solution was developed for the [RSNA 2024 Lumbar Spine Degenerative Classification](https://www.kaggle.com/competitions/rsna-2024-lumbar-spine-degenerative-classification/overview) competition on Kaggle, where participants were challenged to create models to detect and classify degenerative spine conditions based on lumbar spine MRI images. The task required building a model capable of predicting five different degenerative spine conditions and their severity levels across multiple disc levels. By simulating the diagnostic process of a radiologist, our model aims to enhance the accuracy and efficiency of lumbar spine assessments.
 
 Our team achieved a [Silver Medal](https://www.kaggle.com/certification/competitions/distiller/rsna-2024-lumbar-spine-degenerative-classification), with a public score of **0.43** and a private score of **0.49**. Our solution showcased the potential for using deep learning models, specifically YOLOv8, to classify lumbar spine conditions with high accuracy, contributing to the potential clinical utility of AI in radiological diagnostics. 🥈
 
-![Daoyuan Li - RSNA 2024 Lumbar Spine](./rsna-2024-lumbar-spine-certificate.png)
+![Daoyuan Li - RSNA 2024 Lumbar Spine](https://raw.githubusercontent.com/DaoyuanLi2816/rsna-2024-lumbar-spine/main/rsna-2024-lumbar-spine-certificate.png)
 
 ## Table of Contents
 
@@ -193,8 +200,8 @@ Our team achieved a silver medal in the RSNA 2024 Lumbar Spine Degenerative Clas
 ## Setup
 
 ```bash
-git clone https://github.com/DaoyuanLi2816/Kaggle-RSNA-2024-Lumbar-Spine-Degenerative-Classification-Silver-Medal.git
-cd Kaggle-RSNA-2024-Lumbar-Spine-Degenerative-Classification-Silver-Medal
+git clone https://github.com/DaoyuanLi2816/rsna-2024-lumbar-spine.git
+cd rsna-2024-lumbar-spine
 pip install -r requirements.txt
 ```
 ## Usage
@@ -216,7 +223,7 @@ If you find this solution helpful, please consider linking back to this reposito
   author       = {Daoyuan Li},
   title        = {RSNA 2024 Lumbar Spine Degenerative Classification (Silver Medal Solution)},
   year         = {2024},
-  howpublished = {https://github.com/DaoyuanLi2816/Kaggle-RSNA-2024-Lumbar-Spine-Degenerative-Classification-Silver-Medal}
+  howpublished = {https://github.com/DaoyuanLi2816/rsna-2024-lumbar-spine}
 }
 ```
 ## Author

--- a/docs/banner.svg
+++ b/docs/banner.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 250" role="img" aria-label="RSNA 2024 — lumbar spine degenerative classification with a three-track YOLOv8 pipeline; Kaggle silver medal">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="55%" stop-color="#172554"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+    <clipPath id="bgclip">
+      <rect x="0" y="0" width="880" height="250" rx="16"/>
+    </clipPath>
+  </defs>
+
+  <rect x="0" y="0" width="880" height="250" rx="16" fill="url(#bg)"/>
+  <g clip-path="url(#bgclip)">
+    <circle cx="790" cy="0" r="190" fill="#60a5fa" opacity="0.08"/>
+    <circle cx="350" cy="265" r="150" fill="#93c5fd" opacity="0.05"/>
+  </g>
+
+  <!-- ===== left column: brand ===== -->
+  <text x="40" y="84" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="44" font-weight="800" fill="#ffffff">RSNA 2024</text>
+  <rect x="42" y="94" width="64" height="3" rx="1.5" fill="#60a5fa" opacity="0.9"/>
+  <text x="40" y="124" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="14.5" fill="#cbd5e1">Lumbar spine degenerative MRI &#183; YOLOv8</text>
+
+  <!-- task chips -->
+  <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="12" text-anchor="middle">
+    <rect x="40" y="140" width="62" height="24" rx="12" fill="#34d399" fill-opacity="0.12" stroke="#34d399" stroke-opacity="0.65"/>
+    <text x="71" y="156" fill="#6ee7b7">detect</text>
+    <rect x="110" y="140" width="64" height="24" rx="12" fill="#60a5fa" fill-opacity="0.12" stroke="#60a5fa" stroke-opacity="0.65"/>
+    <text x="142" y="156" fill="#93c5fd">classify</text>
+    <rect x="182" y="140" width="56" height="24" rx="12" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.65"/>
+    <text x="210" y="156" fill="#fde68a">grade</text>
+  </g>
+
+  <!-- silver medal pill -->
+  <rect x="40" y="178" width="212" height="28" rx="14" fill="#cbd5e1" fill-opacity="0.10" stroke="#cbd5e1" stroke-opacity="0.55"/>
+  <circle cx="58" cy="192" r="8.5" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+  <text x="58" y="195.5" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="9" text-anchor="middle" fill="#e2e8f0">&#9733;</text>
+  <text x="73" y="196" font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="12.5" fill="#e2e8f0">Kaggle Silver &#183; RSNA 2024</text>
+
+  <!-- notebooks pill -->
+  <rect x="40" y="214" width="178" height="26" rx="13" fill="#ffffff" fill-opacity="0.07" stroke="#ffffff" stroke-opacity="0.18"/>
+  <text x="54" y="231" font-family="ui-monospace, SFMono-Regular, Consolas, 'Courier New', monospace" font-size="12.5" fill="#e2e8f0">$ jupyter lab code/</text>
+
+  <!-- ===== card 1: three YOLO tracks ===== -->
+  <g>
+    <rect x="350" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="380" cy="62" r="16" fill="#38bdf8" fill-opacity="0.14" stroke="#38bdf8" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#38bdf8" stroke-width="1.8" stroke-linecap="round">
+      <line x1="372" y1="56" x2="388" y2="56"/>
+      <line x1="372" y1="62" x2="388" y2="62"/>
+      <line x1="372" y1="68" x2="388" y2="68"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="366" y="102" font-size="14" font-weight="700" fill="#f1f5f9">Three YOLO</text>
+      <text x="366" y="120" font-size="14" font-weight="700" fill="#f1f5f9">tracks</text>
+      <text x="366" y="142" font-size="11.5" fill="#94a3b8">one detector per</text>
+      <text x="366" y="158" font-size="11.5" fill="#94a3b8">condition family</text>
+      <text x="366" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">foraminal &#183; canal &#183;</text>
+      <text x="366" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">subarticular</text>
+    </g>
+  </g>
+
+  <!-- ===== card 2: DICOM to YOLO labels ===== -->
+  <g>
+    <rect x="520" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="550" cy="62" r="16" fill="#34d399" fill-opacity="0.14" stroke="#34d399" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#34d399" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <rect x="542" y="54" width="16" height="16" rx="2"/>
+      <circle cx="550" cy="62" r="3.2"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="536" y="102" font-size="14" font-weight="700" fill="#f1f5f9">DICOM &#8594;</text>
+      <text x="536" y="120" font-size="14" font-weight="700" fill="#f1f5f9">YOLO labels</text>
+      <text x="536" y="142" font-size="11.5" fill="#94a3b8">expert coordinates</text>
+      <text x="536" y="158" font-size="11.5" fill="#94a3b8">become boxes</text>
+      <text x="536" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">3 data-gen notebooks,</text>
+      <text x="536" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">5-fold splits</text>
+    </g>
+  </g>
+
+  <!-- ===== card 3: severity as classes ===== -->
+  <g>
+    <rect x="690" y="30" width="156" height="190" rx="12" fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="720" cy="62" r="16" fill="#a78bfa" fill-opacity="0.14" stroke="#a78bfa" stroke-opacity="0.55" stroke-width="1.4"/>
+    <g stroke="#a78bfa" stroke-width="1.8" stroke-linecap="round">
+      <line x1="714" y1="68" x2="714" y2="62"/>
+      <line x1="720" y1="68" x2="720" y2="57"/>
+      <line x1="726" y1="68" x2="726" y2="52"/>
+    </g>
+    <g font-family="-apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+      <text x="706" y="102" font-size="14" font-weight="700" fill="#f1f5f9">Severity</text>
+      <text x="706" y="120" font-size="14" font-weight="700" fill="#f1f5f9">as classes</text>
+      <text x="706" y="142" font-size="11.5" fill="#94a3b8">normal-mild, moderate,</text>
+      <text x="706" y="158" font-size="11.5" fill="#94a3b8">severe, per disc level</text>
+      <text x="706" y="180" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">25 targets &#8212;</text>
+      <text x="706" y="195" font-size="10.5" fill="#fcd34d" fill-opacity="0.9">5 conditions &#215; 5 levels</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The repository has been renamed **Kaggle-RSNA-2024-Lumbar-Spine-Degenerative-Classification-Silver-Medal → rsna-2024-lumbar-spine** (GitHub redirects old links). This PR:

- adds the unified portfolio masthead: self-contained SVG banner (`docs/banner.svg`, deep-blue palette) — *RSNA 2024* wordmark, `detect / classify / grade` chips, *Kaggle Silver* pill, and three feature cards (three YOLO tracks · DICOM → YOLO labels · severity as classes, 5 conditions × 5 disc levels)
- centers the badge row, adds a license badge, links the Kaggle badge to the certification page
- updates clone/citation URLs to the new name; certificate image switches to an absolute URL

Layout verified by rasterizing the SVG with headless Edge. Topics and the sidebar homepage (Kaggle competition page) were updated via `gh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)